### PR TITLE
Add attribute retries in __init__

### DIFF
--- a/tradingbot/binancefutures.py
+++ b/tradingbot/binancefutures.py
@@ -29,6 +29,7 @@ class BinanceFutures:
         self.orderIDPrefix = orderIDPrefix
         self.last_price = 0
         self.open_orders_ws = {}
+        self.retries = 0  # initialize counter
 
     def open_orders_active(self):
         return {order_id: order for order_id, order in self.open_orders_ws.items() if order['status'] in ['PENDING_NEW', 'NEW', 'PARTIALLY_FILLED']}


### PR DESCRIPTION
This fixes the problem:

```console
AttributeError: 'BinanceFutures' object has no attribute 'retries'
```

The problem could be reproduced, for example, by running with no internet connection.